### PR TITLE
(#8) fix: update uv dependency management configuration

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,6 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install depencencies
-        run: uv sync --group dev
+        run: uv sync --extra dev
       - name: Deploy docs
         run: mkdocs gh-deploy --force

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  UV_FROZEN: true
+  # UV_FROZEN: true # requires uv.lock file
   FORCE_COLOR: 1
 
 jobs:


### PR DESCRIPTION
- Change `uv sync --group dev` to `uv sync --extra dev` in docs workflow to use correct flag for development dependencies
- Comment out UV_FROZEN environment variable in test workflow as it requires a uv.lock file that is not present

These changes align with uv's dependency management syntax and prevent CI failures due to missing lock file.