### PR TITLE
(#77) Simplify area_def definition

### DIFF
--- a/src/satctl/sources/base.py
+++ b/src/satctl/sources/base.py
@@ -559,42 +559,6 @@ class DataSource(ABC):
                 filtered[dataset_name] = file_name
         return filtered
 
-    def _create_area_from_params(
-        self,
-        params: ConversionParams,
-        scene: Scene | None = None,
-    ) -> AreaDefinition:
-        """Create area definition from conversion params, using scene extent if no geometry.
-
-        Args:
-            params (ConversionParams): Conversion parameters with CRS and optional geometry
-            scene (Scene | None): Optional scene for extracting extent when no geometry provided. Defaults to None.
-
-        Returns:
-            AreaDefinition: AreaDefinition for resampling
-
-        Raises:
-            ValueError: If scene is None when area_geometry is also None
-        """
-        if params.area_geometry is not None:
-            return self.define_area(
-                target_crs=params.target_crs_obj,
-                area=params.area_geometry,
-                source_crs=params.source_crs_obj,
-                resolution=params.resolution,
-            )
-        else:
-            if scene is None:
-                raise ValueError(
-                    "Invalid configuration: scene parameter is required when area_geometry is not provided"
-                )
-            return self.define_area(
-                target_crs=params.target_crs_obj,
-                scene=scene,
-                source_crs=params.source_crs_obj,
-                resolution=params.resolution,
-            )
-
     def _write_scene_datasets(
         self,
         scene: Scene,

--- a/src/satctl/sources/earthdata.py
+++ b/src/satctl/sources/earthdata.py
@@ -540,7 +540,13 @@ class EarthDataSource(DataSource):
         scene = self.load_scene(item, datasets=list(datasets_dict.values()))
 
         # Define area using base class helper
-        area_def = self._create_area_from_params(params, scene)
+        area_def = self.define_area(
+            target_crs=params.target_crs_obj,
+            area=params.area_geometry,
+            scene=scene,
+            source_crs=params.source_crs_obj,
+            resolution=params.resolution,
+        )
         scene = self.resample(scene, area_def=area_def)
 
         # Write datasets using base class helper

--- a/src/satctl/sources/mtg.py
+++ b/src/satctl/sources/mtg.py
@@ -308,7 +308,13 @@ class MTGSource(DataSource):
             scene = self.load_scene(item, datasets=list(datasets_dict.values()))
 
             # Define area using base class helper
-            area_def = self._create_area_from_params(params, scene)
+            area_def = self.define_area(
+                target_crs=params.target_crs_obj,
+                area=params.area_geometry,
+                scene=scene,
+                source_crs=params.source_crs_obj,
+                resolution=params.resolution,
+            )
             scene = scene.compute()
             scene = self.resample(scene, area_def=area_def)
 

--- a/src/satctl/sources/sentinel1.py
+++ b/src/satctl/sources/sentinel1.py
@@ -445,22 +445,13 @@ class Sentinel1Source(DataSource):
         scene = self.load_scene(item, datasets=list(datasets_dict.values()))
 
         # Define target area for resampling
-        if params.area_geometry is not None:
-            # User provided AOI - use it with specified CRS and resolution
-            area_def = self.define_area(
-                target_crs=params.target_crs_obj,
-                area=params.area_geometry,
-                source_crs=params.source_crs_obj,
-                resolution=params.resolution,
-            )
-        else:
-            # No AOI provided - use entire granule extent
-            area_def = self.define_area(
-                target_crs=params.target_crs_obj,
-                scene=scene,
-                source_crs=params.source_crs_obj,
-                resolution=params.resolution,
-            )
+        area_def = self.define_area(
+            target_crs=params.target_crs_obj,
+            area=params.area_geometry,
+            scene=scene,
+            source_crs=params.source_crs_obj,
+            resolution=params.resolution,
+        )
 
         # Resample to target area
         scene = self.resample(scene, area_def=area_def)

--- a/src/satctl/sources/sentinel2.py
+++ b/src/satctl/sources/sentinel2.py
@@ -387,7 +387,13 @@ class Sentinel2Source(DataSource):
         scene = self.load_scene(item, datasets=list(datasets_dict.values()))
 
         # Define area using base class helper
-        area_def = self._create_area_from_params(params, scene)
+        area_def = self.define_area(
+            target_crs=params.target_crs_obj,
+            area=params.area_geometry,
+            scene=scene,
+            source_crs=params.source_crs_obj,
+            resolution=params.resolution,
+        )
         scene = self.resample(scene, area_def=area_def)
 
         # Write datasets using base class helper

--- a/src/satctl/sources/sentinel3.py
+++ b/src/satctl/sources/sentinel3.py
@@ -251,7 +251,13 @@ class Sentinel3Source(DataSource):
         scene = self.load_scene(item, datasets=list(datasets_dict.values()))
 
         # Define area using base class helper
-        area_def = self._create_area_from_params(params, scene)
+        area_def = self.define_area(
+            target_crs=params.target_crs_obj,
+            area=params.area_geometry,
+            scene=scene,
+            source_crs=params.source_crs_obj,
+            resolution=params.resolution,
+        )
         scene = self.resample(scene, area_def=area_def)
 
         # Write datasets using base class helper


### PR DESCRIPTION
- remove _create_area_from_params from DataSource
- use  define_area in sources with both scene and area args